### PR TITLE
Filtering by multiple tags enabled

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -2,6 +2,10 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.TagMatchesPredicate;
@@ -22,8 +26,19 @@ public class FilterCommandParser implements Parser<FilterCommand> {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
         }
+        return new FilterCommand(new TagMatchesPredicate(toList(trimmedArgs)));
+    }
 
-        return new FilterCommand(new TagMatchesPredicate(trimmedArgs));
+    /**
+     * Splits the combination of tag queries into list entries.
+     */
+    private List<String> toList(String trimmedArgs) {
+        String[] splitTags = trimmedArgs.split(" ");
+        List<String> tagQueries = new ArrayList<>();
+        for (String tag : splitTags) {
+            tagQueries.add(tag.trim().toLowerCase());
+        }
+        return tagQueries;
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -2,9 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.Arrays;
 
 import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -26,19 +24,10 @@ public class FilterCommandParser implements Parser<FilterCommand> {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
         }
-        return new FilterCommand(new TagMatchesPredicate(toList(trimmedArgs)));
-    }
 
-    /**
-     * Splits the combination of tag queries into list entries.
-     */
-    private List<String> toList(String trimmedArgs) {
-        String[] splitTags = trimmedArgs.split(" ");
-        List<String> tagQueries = new ArrayList<>();
-        for (String tag : splitTags) {
-            tagQueries.add(tag.trim().toLowerCase());
-        }
-        return tagQueries;
+        String[] tagQueries = trimmedArgs.split("\\s+");
+
+        return new FilterCommand(new TagMatchesPredicate(Arrays.asList(tagQueries)));
     }
 
 }

--- a/src/main/java/seedu/address/model/person/TagMatchesPredicate.java
+++ b/src/main/java/seedu/address/model/person/TagMatchesPredicate.java
@@ -3,13 +3,13 @@ package seedu.address.model.person;
 import java.util.List;
 import java.util.function.Predicate;
 
+import seedu.address.commons.util.StringUtil;
 import seedu.address.model.tag.Tag;
 
 /**
  * Tests that any of a {@code Person}'s {@code Tag} matches any of the keywords given.
  */
 public class TagMatchesPredicate implements Predicate<Person> {
-
     private final List<String> tagQueries;
 
     public TagMatchesPredicate(List<String> tagQueries) {
@@ -18,15 +18,10 @@ public class TagMatchesPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
-        boolean contains = false;
-        for (Tag tag : person.getTags()) {
-            for (String tagQuery : tagQueries) {
-                if ((tag.tagName).equalsIgnoreCase(tagQuery)) {
-                    contains = true;
-                }
-            }
-        }
-        return contains;
+        String allTags = person.getTags().toString().replaceAll("\\[|\\]","").replaceAll(","," ");
+
+        return tagQueries.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(allTags, keyword));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/TagMatchesPredicate.java
+++ b/src/main/java/seedu/address/model/person/TagMatchesPredicate.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
-import seedu.address.model.tag.Tag;
 
 /**
  * Tests that any of a {@code Person}'s {@code Tag} matches any of the keywords given.
@@ -18,7 +17,8 @@ public class TagMatchesPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
-        String allTags = person.getTags().toString().replaceAll("\\[|\\]","").replaceAll(","," ");
+        String allTags = person.getTags().toString()
+                .replaceAll("\\[|\\]", "").replaceAll(",", " ");
 
         return tagQueries.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(allTags, keyword));

--- a/src/main/java/seedu/address/model/person/TagMatchesPredicate.java
+++ b/src/main/java/seedu/address/model/person/TagMatchesPredicate.java
@@ -1,5 +1,6 @@
 package seedu.address.model.person;
 
+import java.util.List;
 import java.util.function.Predicate;
 
 import seedu.address.model.tag.Tag;
@@ -9,18 +10,20 @@ import seedu.address.model.tag.Tag;
  */
 public class TagMatchesPredicate implements Predicate<Person> {
 
-    private final String tagQuery;
+    private final List<String> tagQueries;
 
-    public TagMatchesPredicate(String tagQuery) {
-        this.tagQuery = tagQuery;
+    public TagMatchesPredicate(List<String> tagQueries) {
+        this.tagQueries = tagQueries;
     }
 
     @Override
     public boolean test(Person person) {
         boolean contains = false;
         for (Tag tag : person.getTags()) {
-            if ((tag.tagName).equalsIgnoreCase(tagQuery)) {
-                contains = true;
+            for (String tagQuery : tagQueries) {
+                if ((tag.tagName).equalsIgnoreCase(tagQuery)) {
+                    contains = true;
+                }
             }
         }
         return contains;
@@ -30,6 +33,6 @@ public class TagMatchesPredicate implements Predicate<Person> {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof TagMatchesPredicate // instanceof handles nulls
-                && tagQuery.equals(((TagMatchesPredicate) other).tagQuery)); // state check
+                && tagQueries.equals(((TagMatchesPredicate) other).tagQueries)); // state check
     }
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -5,7 +5,7 @@
     "phone" : "94351253",
     "email" : "alice@example.com",
     "address" : "123, Jurong West Ave 6, #08-111",
-    "tagged" : [ "friends" ],
+    "tagged" : [ "colleagues" ],
     "photo" : "alice.png"
   }, {
     "name" : "Benson Meier",

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -29,8 +29,10 @@ public class FilterCommandTest {
 
     @Test
     public void equals() {
-        TagMatchesPredicate firstPredicate = new TagMatchesPredicate("first");
-        TagMatchesPredicate secondPredicate = new TagMatchesPredicate("second");
+        TagMatchesPredicate firstPredicate =
+                new TagMatchesPredicate(Collections.singletonList("first"));
+        TagMatchesPredicate secondPredicate =
+                new TagMatchesPredicate(Collections.singletonList("second"));
 
         FilterCommand filterFirstCommand = new FilterCommand(firstPredicate);
         FilterCommand filterSecondCommand = new FilterCommand(secondPredicate);
@@ -65,7 +67,7 @@ public class FilterCommandTest {
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        TagMatchesPredicate predicate = preparePredicate("friends");
+        TagMatchesPredicate predicate = preparePredicate("friends colleagues");
         FilterCommand command = new FilterCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -73,9 +75,9 @@ public class FilterCommandTest {
     }
 
     /**
-     * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
+     * Parses {@code userInput} into a {@code TagMatchesPredicate}.
      */
     private TagMatchesPredicate preparePredicate(String userInput) {
-        return new TagMatchesPredicate(userInput.trim());
+        return new TagMatchesPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -81,10 +81,10 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_filter() throws Exception {
-        String tagQuery = "foo";
+        List<String> tagQueries = Arrays.asList("foo", "bar", "baz");
         FilterCommand command = (FilterCommand) parser.parseCommand(
-                FilterCommand.COMMAND_WORD + " " + tagQuery);
-        assertEquals(new FilterCommand(new TagMatchesPredicate(tagQuery)), command);
+                FilterCommand.COMMAND_WORD + " " + tagQueries.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FilterCommand(new TagMatchesPredicate(tagQueries)), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -4,6 +4,8 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
+import java.util.Arrays;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FilterCommand;
@@ -19,14 +21,14 @@ public class FilterCommandParserTest {
     }
 
     @Test
-    public void parse_validArgs_returnsFindCommand() {
+    public void parse_validArgs_returnsFilterCommand() {
         // no leading and trailing whitespaces
         FilterCommand expectedFilterCommand =
-                new FilterCommand(new TagMatchesPredicate("friend"));
-        assertParseSuccess(parser, "friend", expectedFilterCommand);
+                new FilterCommand(new TagMatchesPredicate(Arrays.asList("captain", "freestyle")));
+        assertParseSuccess(parser, "captain freestyle", expectedFilterCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n friend \n \t", expectedFilterCommand);
+        assertParseSuccess(parser, " \n captain \n \t freestyle  \t", expectedFilterCommand);
     }
 
 }

--- a/src/test/java/seedu/address/model/person/TagMatchesPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/TagMatchesPredicateTest.java
@@ -3,6 +3,10 @@ package seedu.address.model.person;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.testutil.PersonBuilder;
@@ -11,24 +15,24 @@ public class TagMatchesPredicateTest {
 
     @Test
     public void equals() {
-        String firstPredicateKeyword = "first";
-        String secondPredicateKeyword = "second";
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
 
-        TagMatchesPredicate firstPredicate = new TagMatchesPredicate(firstPredicateKeyword);
-        TagMatchesPredicate secondPredicate = new TagMatchesPredicate(secondPredicateKeyword);
+        TagMatchesPredicate firstPredicate = new TagMatchesPredicate(firstPredicateKeywordList);
+        TagMatchesPredicate secondPredicate = new TagMatchesPredicate(secondPredicateKeywordList);
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
-        TagMatchesPredicate firstPredicateCopy = new TagMatchesPredicate(firstPredicateKeyword);
+        TagMatchesPredicate firstPredicateCopy = new TagMatchesPredicate(firstPredicateKeywordList);
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
         // different types -> returns false
         assertFalse(firstPredicate.equals(1));
 
         // null -> returns false
-        assertFalse(firstPredicate == null);
+        assertFalse(firstPredicate.equals(null));
 
         // different person -> returns false
         assertFalse(firstPredicate.equals(secondPredicate));
@@ -36,24 +40,31 @@ public class TagMatchesPredicateTest {
 
     @Test
     public void test_tagMatchesQuery_returnsTrue() {
-        // One keyword
-        TagMatchesPredicate predicate = new TagMatchesPredicate("friend");
-        assertTrue(predicate.test(new PersonBuilder().withTags("friend").build()));
+        // One tag
+        TagMatchesPredicate predicate = new TagMatchesPredicate(Collections.singletonList("captain"));
+        assertTrue(predicate.test(new PersonBuilder().withTags("captain").build()));
 
-        // Mixed-case keywords
-        predicate = new TagMatchesPredicate("FRIEND");
-        assertTrue(predicate.test(new PersonBuilder().withTags("friend").build()));
+        // Multiple tag
+        predicate = new TagMatchesPredicate(Arrays.asList("captain", "freestyle"));
+        assertTrue(predicate.test(new PersonBuilder().withTags("captain", "freestyle").build()));
+
+        // Only one matching tag
+        predicate = new TagMatchesPredicate(Arrays.asList("captain", "freestyle"));
+        assertTrue(predicate.test(new PersonBuilder().withTags("captain", "butterfly").build()));
+
+        // Mixed-case tags
+        predicate = new TagMatchesPredicate(Arrays.asList("cApTaIn", "FrEeStYlE"));
+        assertTrue(predicate.test(new PersonBuilder().withTags("captain", "freestyle").build()));
     }
 
     @Test
     public void test_tagDoesNotMatchQuery_returnsFalse() {
-        // Zero keywords
-        TagMatchesPredicate predicate = new TagMatchesPredicate("");
-        assertFalse(predicate.test(new PersonBuilder().withTags("friend").build()));
+        // Zero tags
+        TagMatchesPredicate predicate = new TagMatchesPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withTags("captain").build()));
 
-        // Non-matching keyword
-        predicate = new TagMatchesPredicate("colleague");
-        assertFalse(predicate.test(new PersonBuilder().withTags("college").build()));
-
+        // Non-matching tag
+        predicate = new TagMatchesPredicate(Arrays.asList("captain"));
+        assertFalse(predicate.test(new PersonBuilder().withTags("butterfly", "injured").build()));
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -28,7 +28,7 @@ public class TypicalPersons {
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
             .withPhone("94351253")
-            .withTags("friends").withPhoto("alice.png")
+            .withTags("colleagues").withPhoto("alice.png")
             .build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")


### PR DESCRIPTION
Hi guys!

Currently the implementation for this similar to the `find`, where as long as the athlete contains a tag matching the keyword, they will be shown.

Eg. if you search `filter butterfly freestyle`, as long as the athlete has `butterfly` tag **or** `freestyle` tag, they will be shown.

We could use a more specific matching (eg. only athletes with **both** `butterfly` and `freestyle` will be shown) but that would not be consistent with how `find` was implemented in AB3.

Feel free to look through my files changed and leave feedback 🤗.

Closes #76