### PR TITLE
Rename date class to AthletickDate

### DIFF
--- a/src/main/java/seedu/address/model/date/AthletickDate.java
+++ b/src/main/java/seedu/address/model/date/AthletickDate.java
@@ -10,7 +10,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 /**
  * Represents date used in attendance and performance recording.
  */
-public class TrainingDate {
+public class AthletickDate {
 
     private static final String WRONG_DATE_FORMAT = "Invalid date specified.";
 
@@ -18,7 +18,7 @@ public class TrainingDate {
     private int month;
     private int year;
 
-    public TrainingDate(String date) throws ParseException {
+    public AthletickDate(String date) throws ParseException {
         requireNonNull(date);
         processDate(date);
     }

--- a/src/test/java/seedu/address/model/date/AthletickDateTest.java
+++ b/src/test/java/seedu/address/model/date/AthletickDateTest.java
@@ -8,43 +8,43 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.parser.exceptions.ParseException;
 
-public class TrainingDateTest {
+public class AthletickDateTest {
 
     @Test
     public void constructor_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new TrainingDate(null));
+        assertThrows(NullPointerException.class, () -> new AthletickDate(null));
     }
 
     @Test
     public void constructor_invalidTrainingDate_throwsParseException() {
         String invalidTrainingDate = "";
-        assertThrows(ParseException.class, () -> new TrainingDate(invalidTrainingDate));
+        assertThrows(ParseException.class, () -> new AthletickDate(invalidTrainingDate));
     }
 
     @Test
     public void constructor_validTrainingDate_success() throws ParseException {
         String validTrainingDate = "01012000";
-        TrainingDate td = new TrainingDate(validTrainingDate);
+        AthletickDate td = new AthletickDate(validTrainingDate);
         assertTrue(true);
     }
 
     @Test
     public void getDay() throws ParseException {
-        TrainingDate td = new TrainingDate("01012000");
+        AthletickDate td = new AthletickDate("01012000");
         int day = td.getDay();
         assertEquals(1, day);
     }
 
     @Test
     public void getMonth() throws ParseException {
-        TrainingDate td = new TrainingDate("01012000");
+        AthletickDate td = new AthletickDate("01012000");
         int month = td.getMonth();
         assertEquals(1, month);
     }
 
     @Test
     public void getYear() throws ParseException {
-        TrainingDate td = new TrainingDate("01012000");
+        AthletickDate td = new AthletickDate("01012000");
         int year = td.getYear();
         assertEquals(2000, year);
     }


### PR DESCRIPTION
Renaming it from `TrainingDate` to a general `AthletickDate` since it is used not only by `Training`, but for `Performance` recording as well.

@jeunhoe you can now use this class instead of a `String` for your dates! 👍🏻