### PR TITLE
Implement Calendar-compatible methods for retrieving Performance

### DIFF
--- a/src/main/java/seedu/address/model/EventList.java
+++ b/src/main/java/seedu/address/model/EventList.java
@@ -2,9 +2,12 @@ package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.HashMap;
 import java.util.List;
 
 import javafx.collections.ObservableList;
+import seedu.address.model.date.AthletickDate;
+import seedu.address.model.performance.CalendarCompatibleRecord;
 import seedu.address.model.performance.Event;
 import seedu.address.model.performance.Record;
 import seedu.address.model.performance.UniqueEventList;
@@ -58,6 +61,22 @@ public class EventList implements ReadOnlyEvents {
     }
 
     //// event-level operations
+
+    /**
+     * Retrieves Calendar-compatible records for all events.
+     */
+    public HashMap<Event, List<CalendarCompatibleRecord>> getCalendarCompatiblePerformance(AthletickDate date) {
+        requireNonNull(date);
+        return events.getCalendarCompatiblePerformance(date);
+    }
+
+    /**
+     * Checks if there are any recorded performances on a specified date.
+     */
+    public boolean hasPerformanceOn(AthletickDate date) {
+        requireNonNull(date);
+        return events.hasPerformanceOn(date);
+    }
 
     /**
      * Returns true if an event with the same name as {@code event} exists in the events list.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,10 +1,14 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.date.AthletickDate;
+import seedu.address.model.performance.CalendarCompatibleRecord;
 import seedu.address.model.performance.Event;
 import seedu.address.model.performance.Record;
 import seedu.address.model.person.Person;
@@ -114,4 +118,8 @@ public interface Model {
     ReadOnlyEvents getEventList();
 
     String addRecord(String eventName, Person person, Record record);
+
+    HashMap<Event, List<CalendarCompatibleRecord>> getCalendarCompatiblePerformance(AthletickDate date);
+
+    boolean hasPerformanceOn(AthletickDate date);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,8 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -14,7 +16,9 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.TrainingCommand;
+import seedu.address.model.date.AthletickDate;
 import seedu.address.model.history.HistoryManager;
+import seedu.address.model.performance.CalendarCompatibleRecord;
 import seedu.address.model.performance.Event;
 import seedu.address.model.performance.Record;
 import seedu.address.model.person.Person;
@@ -246,6 +250,16 @@ public class ModelManager implements Model {
     @Override
     public String addRecord(String eventName, Person person, Record record) {
         return eventList.addRecord(eventName, person, record);
+    }
+
+    @Override
+    public HashMap<Event, List<CalendarCompatibleRecord>> getCalendarCompatiblePerformance(AthletickDate date) {
+        return eventList.getCalendarCompatiblePerformance(date);
+    }
+
+    @Override
+    public boolean hasPerformanceOn(AthletickDate date) {
+        return eventList.hasPerformanceOn(date);
     }
 
 }

--- a/src/main/java/seedu/address/model/performance/CalendarCompatibleRecord.java
+++ b/src/main/java/seedu/address/model/performance/CalendarCompatibleRecord.java
@@ -1,0 +1,20 @@
+package seedu.address.model.performance;
+
+import seedu.address.model.person.Person;
+
+/**
+ * Wrapper for performance record that will be displayed in the Calendar.
+ * Differs from Record class in that the attributes are athlete and timing, instead of date and timing since
+ * the date for a CalendarCompatibleRecord is fixed already.
+ */
+public class CalendarCompatibleRecord {
+
+    private Person athlete;
+    private String timing;
+
+    public CalendarCompatibleRecord(Person athlete, String timing) {
+        this.athlete = athlete;
+        this.timing = timing;
+    }
+
+}

--- a/src/main/java/seedu/address/model/performance/Event.java
+++ b/src/main/java/seedu/address/model/performance/Event.java
@@ -3,7 +3,9 @@ package seedu.address.model.performance;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import seedu.address.model.date.AthletickDate;
 import seedu.address.model.person.Person;
 
 /**
@@ -14,7 +16,7 @@ public class Event {
     public static final String MESSAGE_CONSTRAINTS = "%1$s event has not been created.\n"
             + "Please use the event command to create the event first.";
 
-    public static final String INVALID_NAME_MESSAGE_CONSTRAINTS = "Evnt name should not begin with a space.\n";
+    public static final String INVALID_NAME_MESSAGE_CONSTRAINTS = "Event name should not begin with a space.\n";
 
     /*
      * The first character of the address must not be a whitespace,
@@ -69,6 +71,44 @@ public class Event {
 
     public HashMap<Person, List<Record>> getPerformances() {
         return performances;
+    }
+
+    /**
+     * Retrieves a list of Calendar-compatible records for the Calendar.
+     * @param date of Calendar-compatible records.
+     */
+    public List<CalendarCompatibleRecord> getCalendarCompatibleRecords(AthletickDate date) {
+        List<CalendarCompatibleRecord> ccrList = new ArrayList<>();
+        performances.forEach((person, records) -> {
+            String timing = null;
+            for (Record record : records) {
+                if (record.getDate().equals(date)) {
+                    timing = record.getTiming();
+                }
+            }
+            if (timing == null) {
+                timing = "This person does not have a performance record for " + name + " event on " + date.toString();
+            }
+            CalendarCompatibleRecord ccr = new CalendarCompatibleRecord(person, timing);
+            ccrList.add(ccr);
+        });
+        return ccrList;
+    }
+
+    /**
+     * Checks if this event has a recorded performance on the given date.
+     */
+    public boolean hasPerformanceOn(AthletickDate date) {
+        AtomicBoolean answer = new AtomicBoolean(false);
+        performances.forEach((person, records) -> {
+            for (Record record : records) {
+                if (record.getDate().equals(date)) {
+                    answer.set(true);
+                    break;
+                }
+            }
+        });
+        return false;
     }
 
     /**

--- a/src/main/java/seedu/address/model/performance/UniqueEventList.java
+++ b/src/main/java/seedu/address/model/performance/UniqueEventList.java
@@ -3,11 +3,13 @@ package seedu.address.model.performance;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.date.AthletickDate;
 import seedu.address.model.performance.exceptions.DuplicateEventException;
 
 /**
@@ -51,6 +53,29 @@ public class UniqueEventList implements Iterable<Event> {
             }
         }
         return null;
+    }
+
+    /**
+     * Method for Shawn to retrieve performance records on a particular day for the Calendar feature.
+     */
+    public HashMap<Event, List<CalendarCompatibleRecord>> getCalendarCompatiblePerformance(AthletickDate date) {
+        HashMap<Event, List<CalendarCompatibleRecord>> hm = new HashMap<>();
+        for (Event event : internalList) {
+            hm.put(event, event.getCalendarCompatibleRecords(date));
+        }
+        return hm;
+    }
+
+    /**
+     * Checks if there are any recorded performances on the specified date.
+     */
+    public boolean hasPerformanceOn(AthletickDate date) {
+        for (Event event : internalList) {
+            if (event.hasPerformanceOn(date)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -9,6 +9,8 @@ import static seedu.address.testutil.Assert.assertThrows;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -22,6 +24,8 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyEvents;
 import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.date.AthletickDate;
+import seedu.address.model.performance.CalendarCompatibleRecord;
 import seedu.address.model.performance.Event;
 import seedu.address.model.performance.Record;
 import seedu.address.model.person.Person;
@@ -207,6 +211,16 @@ public class AddCommandTest {
         @Override
         public String addRecord(String eventName, Person person, Record record) {
             return null;
+        }
+
+        @Override
+        public HashMap<Event, List<CalendarCompatibleRecord>> getCalendarCompatiblePerformance(AthletickDate date) {
+            return null;
+        }
+
+        @Override
+        public boolean hasPerformanceOn(AthletickDate date) {
+            return false;
         }
     }
 


### PR DESCRIPTION
Hi @shawnlsj97 here are the methods you requested for integrating `Performance` with your `Calendar` feature.

The `CalendarCompatibleRecord` is a wrapper class for `Person` and the `String` timing. There is a lot of nesting here, so feel free to clarify any issues with me, if any.

The methods can be called through `Model`:

- `model.getCalendarCompatiblePerformance(date)` will return `HashMap<Event, List<CalendarCompatibleRecord>>` 
If the `Person` does not have a timing on that day, I have added a message indicating so.
However, I believe the `Person` should not even be there at all, but I am not sure hence the message for good measure.

- `model.hasPerformanceOn(date)` will return `boolean`

❗️`date` has to be an `AthletickDate` object

Closes #95 